### PR TITLE
A few fixes

### DIFF
--- a/src/sfml/graphics/rect.zig
+++ b/src/sfml/graphics/rect.zig
@@ -40,7 +40,7 @@ pub fn Rect(comptime T: type) type {
         /// This is mainly for the inner workings of this wrapper
         pub fn fromCSFML(rect: CsfmlEquivalent) Self {
             if (CsfmlEquivalent == void) @compileError("This rectangle type doesn't have a CSFML equivalent.");
-            return Self.init(rect.left, rect.top, rect.width, rect.width);
+            return Self.init(rect.left, rect.top, rect.width, rect.height);
         }
 
         /// Checks if a point is inside this recangle

--- a/src/sfml/graphics/sprite.zig
+++ b/src/sfml/graphics/sprite.zig
@@ -105,12 +105,12 @@ pub const Sprite = struct {
         sf.c.sfSprite_setTexture(self.ptr, tex, 1);
     }
     /// Gets the sub-rectangle of the texture that the sprite will display
-    pub fn getTextureRect(self: Self) sf.FloatRect {
-        return sf.FloatRect.fromCSFML(sf.c.sfSprite_getTextureRect(self.ptr));
+    pub fn getTextureRect(self: Self) sf.IntRect {
+        return sf.IntRect.fromCSFML(sf.c.sfSprite_getTextureRect(self.ptr));
     }
     /// Sets the sub-rectangle of the texture that the sprite will display
-    pub fn setTextureRect(self: Self, rect: sf.FloatRect) void {
-        sf.c.sfSprite_getCircleRect(self.ptr, rect.toCSFML());
+    pub fn setTextureRect(self: Self, rect: sf.IntRect) void {
+        sf.c.sfSprite_setTextureRect(self.ptr, rect.toCSFML());
     }
 
     /// Pointer to the csfml structure


### PR DESCRIPTION
I found a few things to fix:

- Use IntRect for Sprite's getTextureRect/setTextureRect since CSFML uses sfIntRect for those
- Fixed wrong call inside Sprite.setTextureRect
- The width was being set to the height in Rect.fromCSFML