### PR TITLE
Remove hacks, correct import case, conform to `usingnamespace` semantics

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,9 +35,9 @@ This is how you get started :
 //! for instance, in this page: https://www.sfml-dev.org/tutorials/2.5/start-vc.php
 
 const sf = struct {
-    pub usingnamespace @import("sfml");
-    pub usingnamespace graphics;
-    pub usingnamespace window;
+    usingnamespace @import("sfml");
+    usingnamespace sf.graphics;
+    usingnamespace sf.window;
 };
 
 pub fn main() !void {

--- a/src/examples/green_circle.zig
+++ b/src/examples/green_circle.zig
@@ -2,9 +2,9 @@
 //! for instance, in this page: https://www.sfml-dev.org/tutorials/2.5/start-vc.php
 
 const sf = struct {
-    pub usingnamespace @import("sfml");
-    pub usingnamespace graphics;
-    pub usingnamespace window;
+    usingnamespace @import("sfml");
+    usingnamespace sf.graphics;
+    usingnamespace sf.window;
 };
 
 pub fn main() !void {

--- a/src/sfml/audio/Sound.zig
+++ b/src/sfml/audio/Sound.zig
@@ -1,8 +1,8 @@
-//! Regular sound that can be played in the audio environment. 
+//! Regular sound that can be played in the audio environment.
 
 const sf = struct {
     pub usingnamespace @import("../sfml.zig");
-    pub usingnamespace audio;
+    pub usingnamespace sf.audio;
 };
 
 const Sound = @This();

--- a/src/sfml/graphics/CircleShape.zig
+++ b/src/sfml/graphics/CircleShape.zig
@@ -2,8 +2,8 @@
 
 const sf = struct {
     pub usingnamespace @import("../sfml.zig");
-    pub usingnamespace system;
-    pub usingnamespace graphics;
+    pub usingnamespace sf.system;
+    pub usingnamespace sf.graphics;
 };
 
 const CircleShape = @This();

--- a/src/sfml/graphics/Image.zig
+++ b/src/sfml/graphics/Image.zig
@@ -2,8 +2,8 @@
 
 const sf = struct {
     pub usingnamespace @import("../sfml.zig");
-    pub usingnamespace system;
-    pub usingnamespace graphics;
+    pub usingnamespace sf.system;
+    pub usingnamespace sf.graphics;
 };
 
 const std = @import("std");

--- a/src/sfml/graphics/Image.zig
+++ b/src/sfml/graphics/Image.zig
@@ -72,15 +72,8 @@ pub fn setPixel(self: Image, pixel_pos: sf.Vector2u, color: sf.Color) void {
 
 /// Gets the size of this image
 pub fn getSize(self: Image) sf.Vector2u {
-    // This is a hack
-    _ = sf.c.sfImage_getSize(self.ptr);
-    // Register Rax holds the return val of function calls that can fit in a register
-    const rax: usize = asm volatile (""
-        : [ret] "={rax}" (-> usize)
-    );
-    var x: u32 = @truncate(u32, (rax & 0x00000000FFFFFFFF) >> 00);
-    var y: u32 = @truncate(u32, (rax & 0xFFFFFFFF00000000) >> 32);
-    return sf.Vector2u{ .x = x, .y = y };
+    const size = sf.c.sfImage_getSize(self.ptr);
+    return sf.Vector2u{ .x = size.x, .y = size.y };
 }
 
 /// Pointer to the csfml texture

--- a/src/sfml/graphics/RectangleShape.zig
+++ b/src/sfml/graphics/RectangleShape.zig
@@ -2,8 +2,8 @@
 
 const sf = struct {
     pub usingnamespace @import("../sfml.zig");
-    pub usingnamespace system;
-    pub usingnamespace graphics;
+    pub usingnamespace sf.system;
+    pub usingnamespace sf.graphics;
 };
 
 const RectangleShape = @This();
@@ -124,7 +124,7 @@ ptr: *sf.c.sfRectangleShape,
 
 test "rectangle shape: sane getters and setters" {
     const tst = @import("std").testing;
-    
+
     var rect = try RectangleShape.create(sf.Vector2f{ .x = 30, .y = 50 });
     defer rect.destroy();
 

--- a/src/sfml/graphics/RenderWindow.zig
+++ b/src/sfml/graphics/RenderWindow.zig
@@ -2,8 +2,8 @@
 
 const sf = struct {
     pub usingnamespace @import("../sfml.zig");
-    pub usingnamespace system;
-    pub usingnamespace graphics;
+    pub usingnamespace sf.system;
+    pub usingnamespace sf.graphics;
 };
 
 const RenderWindow = @This();

--- a/src/sfml/graphics/Sprite.zig
+++ b/src/sfml/graphics/Sprite.zig
@@ -2,8 +2,8 @@
 
 const sf = struct {
     pub usingnamespace @import("../sfml.zig");
-    pub usingnamespace system;
-    pub usingnamespace graphics;
+    pub usingnamespace sf.system;
+    pub usingnamespace sf.graphics;
 };
 
 const Sprite = @This();

--- a/src/sfml/graphics/Text.zig
+++ b/src/sfml/graphics/Text.zig
@@ -2,8 +2,8 @@
 
 const sf = struct {
     pub usingnamespace @import("../sfml.zig");
-    pub usingnamespace system;
-    pub usingnamespace graphics;
+    pub usingnamespace sf.system;
+    pub usingnamespace sf.graphics;
 };
 
 const Text = @This();

--- a/src/sfml/graphics/View.zig
+++ b/src/sfml/graphics/View.zig
@@ -2,8 +2,8 @@
 
 const sf = struct {
     pub usingnamespace @import("../sfml.zig");
-    pub usingnamespace system;
-    pub usingnamespace graphics;
+    pub usingnamespace sf.system;
+    pub usingnamespace sf.graphics;
 };
 
 const View = @This();

--- a/src/sfml/graphics/rect.zig
+++ b/src/sfml/graphics/rect.zig
@@ -2,7 +2,7 @@
 
 const sf = struct {
     pub usingnamespace @import("../sfml.zig");
-    pub usingnamespace system;
+    pub usingnamespace sf.system;
 };
 const math = @import("std").math;
 

--- a/src/sfml/graphics/texture.zig
+++ b/src/sfml/graphics/texture.zig
@@ -75,15 +75,8 @@ pub const Texture = union(TextureType) {
 
     /// Gets the size of this image
     pub fn getSize(self: Self) sf.Vector2u {
-        // This is a hack
-        _ = sf.c.sfTexture_getSize(self.get());
-        // Register Rax holds the return val of function calls that can fit in a register
-        const rax: usize = asm volatile (""
-            : [ret] "={rax}" (-> usize)
-        );
-        var x: u32 = @truncate(u32, (rax & 0x00000000FFFFFFFF) >> 00);
-        var y: u32 = @truncate(u32, (rax & 0xFFFFFFFF00000000) >> 32);
-        return sf.Vector2u{ .x = x, .y = y };
+        const size = sf.c.sfTexture_getSize(self.get());
+        return sf.Vector2u{ .x = size.x, .y = size.y };
     }
     /// Gets the pixel count of this image
     pub fn getPixelCount(self: Self) usize {

--- a/src/sfml/graphics/texture.zig
+++ b/src/sfml/graphics/texture.zig
@@ -2,8 +2,8 @@
 
 const sf = struct {
     pub usingnamespace @import("../sfml.zig");
-    pub usingnamespace system;
-    pub usingnamespace graphics;
+    pub usingnamespace sf.system;
+    pub usingnamespace sf.graphics;
 };
 
 const std = @import("std");

--- a/src/sfml/sfml.zig
+++ b/src/sfml/sfml.zig
@@ -17,8 +17,8 @@ pub const system = struct {
 pub const window = struct {
     pub const Event = @import("window/event.zig").Event;
     pub const Style = @import("window/Style.zig");
-    pub const keyboard = @import("window/Keyboard.zig");
-    pub const mouse = @import("window/Mouse.zig");
+    pub const keyboard = @import("window/keyboard.zig");
+    pub const mouse = @import("window/mouse.zig");
 };
 
 pub const graphics = struct {

--- a/src/sfml/system/Clock.zig
+++ b/src/sfml/system/Clock.zig
@@ -2,8 +2,8 @@
 
 const sf = struct {
     pub usingnamespace @import("../sfml.zig");
-    pub usingnamespace system;
-    pub usingnamespace graphics;
+    pub usingnamespace sf.system;
+    pub usingnamespace sf.graphics;
 };
 
 const Clock = @This();

--- a/src/sfml/window/event.zig
+++ b/src/sfml/window/event.zig
@@ -2,7 +2,7 @@
 
 const sf = struct {
     pub usingnamespace @import("../sfml.zig");
-    pub usingnamespace system;
+    pub usingnamespace sf.system;
 };
 
 pub const Event = union(Event.Type) {


### PR DESCRIPTION
Hi there,

Thanks again for your great work on this wrapper. Here are my collected changes for a working build against `zig-master` at the time of writing. `zig test src/sfml/sfml_tests.zig -lc -lcsfml-graphics -lcsfml-audio -lcsfml-system` reports that all the tests passed, and i have been using this version for development for some time now.

The changes are minimal: 
- `@import` is case sensitive
- `pub usingnamespace` is now generally qualified by the name of the struct, `sf`
- master appears to generate correct code for things like `const size = sf.c.sfTexture_getSize(self.get());` so we don't need to mess with x86_64 specific registers and C ABI calling conventions in two methods